### PR TITLE
Rename rule name to use namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ As follows:
     "stylelint-value-border-zero"
   ],
   "rules": {
-    "value-border-zero": {
+    "plugin/value-border-zero": {
       "convention": "0" // Or "none"
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const assign = require('object-assign');
 const stylelint = require('stylelint');
-const ruleName = 'value-border-zero';
+const ruleName = 'plugin/value-border-zero';
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: (convention, opposite) =>
     `'border: ${convention}' is preferred over 'border: ${opposite}'`

--- a/test/index.js
+++ b/test/index.js
@@ -14,18 +14,18 @@ testRule({ convention: '0' }, (tr) => {
   basics(tr);
 
   tr.ok('a { border: 0; }');
-  tr.notOk('a { border: none; }', '\'border: 0\' is preferred over \'border: none\' (value-border-zero)');
+  tr.notOk('a { border: none; }', '\'border: 0\' is preferred over \'border: none\' (plugin/value-border-zero)');
 
   tr.ok('@media print { a { border: 0; }}');
-  tr.notOk('@media print { a { border: none; }}', '\'border: 0\' is preferred over \'border: none\' (value-border-zero)');
+  tr.notOk('@media print { a { border: none; }}', '\'border: 0\' is preferred over \'border: none\' (plugin/value-border-zero)');
 });
 
 testRule({ convention: 'none' }, (tr) => {
   basics(tr);
 
   tr.ok('a { border: none; }');
-  tr.notOk('a { border: 0; }', '\'border: none\' is preferred over \'border: 0\' (value-border-zero)');
+  tr.notOk('a { border: 0; }', '\'border: none\' is preferred over \'border: 0\' (plugin/value-border-zero)');
 
   tr.ok('@media print { a { border: none; }}');
-  tr.notOk('@media print { a { border: 0; }}', '\'border: none\' is preferred over \'border: 0\' (value-border-zero)');
+  tr.notOk('@media print { a { border: 0; }}', '\'border: none\' is preferred over \'border: 0\' (plugin/value-border-zero)');
 });


### PR DESCRIPTION
To avoid the following warning: 
"Plugin rules that aren't namespaced have been deprecated, and in 7.0 they will be disallowed."

According to the documentation the plugin's rule name must be namespaced: http://stylelint.io/developer-guide/plugins/